### PR TITLE
Fix #7: Use unique ID for improvement navigation to avoid slug collisions

### DIFF
--- a/.windsurf/rules/libraries-preferences.md
+++ b/.windsurf/rules/libraries-preferences.md
@@ -8,5 +8,6 @@ If a choice is available, always choose the preferred package over the alternati
 - pandas
 - geopandas
 - FastHTML for web development
+- MonsterUI for the appearance of the web-applications
 - numpy
 - fastcore for convenience functions and writing tests

--- a/.windsurf/rules/process-instructions.md
+++ b/.windsurf/rules/process-instructions.md
@@ -11,6 +11,8 @@ trigger: always_on
 - Write tests using the `fastcore.test` module from `fastcore`.
 - If there are several good solutions or implemenations, explain why you chose the implemented option over the other options.
 - When possible use Fastcore to make Python code more concise, readable, and expressive.
+- Use `FastHTML` for webdevelopment as documented in `./aicontext/fasthtml.md`
+- Use `MonsterUI` for creating the appearance of the web-application as documented in `./aicontext/monsterui.md`.
 
 ## `nbdev` Development Workflow
 
@@ -49,8 +51,19 @@ Use this list as a **"red flag" checklist** while coding—when you spot one of 
 **MANDATORY PROCESS**: Before writing ANY FastHTML code that can have more than one obvious implementation, you MUST:
 
 1. Read [./aicontext/fasthtml.md](cci:7://file:///home/jelle/code/infoflow/aicontext/fasthtml.md:0:0-0:0) 
-2. Identify which documentation webpage is relevant to the task
-3. Read that specific webpage using the appropriate tool
+2. Identify which documentation webpages are relevant to the task
+3. Read those specific webpages using the appropriate tool
 4. Only then write the FastHTML code based on that documentation
+
+This is a PROCESS RULE, not a context rule. It applies every single time a task has more than one obvious sollution. You may only skip this PROCESS RULE for simple tasks when you already know the best answer.
+
+## MonsterUI Development Workflow
+
+**MANDATORY PROCESS**: Before writing ANY MonsterUI code or code to create or alter the appearance of a web-application you MUST follow the next steps if the task can have more than one obvious code implementation:
+
+1. Read `./aicontext/monsterui.md` file 
+2. Identify which documentation webpages are relevant to the task
+3. Read those specific webpages using the appropriate tool
+4. Only then write the MonsterUI code based on that documentation
 
 This is a PROCESS RULE, not a context rule. It applies every single time a task has more than one obvious sollution. You may only skip this PROCESS RULE for simple tasks when you already know the best answer.

--- a/aicontext/monsterui.md
+++ b/aicontext/monsterui.md
@@ -1,0 +1,44 @@
+# MonsterUI Documentation
+
+> MonsterUI is a python library which brings styling to python for FastHTML apps.
+
+## API Reference
+- [API List](https://raw.githubusercontent.com/AnswerDotAI/MonsterUI/refs/heads/main/docs/apilist.txt): Complete API Reference
+
+## Examples
+- [Tasks](https://monsterui.answer.ai/tasks/md): FrankenUI Tasks Example built with MonsterUI (original design by ShadCN)
+- [Playground](https://monsterui.answer.ai/playground/md): FrankenUI Playground Example built with MonsterUI (original design by ShadCN)
+- [Scrollspy](https://monsterui.answer.ai/scrollspy/md): MonsterUI Scrollspy Example application
+- [Auth](https://monsterui.answer.ai/auth/md): FrankenUI Auth Example built with MonsterUI (original design by ShadCN)
+- [Mail](https://monsterui.answer.ai/mail/md): FrankenUI Mail Example built with MonsterUI (original design by ShadCN)
+- [Dashboard](https://monsterui.answer.ai/dashboard/md): FrankenUI Dashboard Example built with MonsterUI (original design by ShadCN)
+- [Ticket](https://monsterui.answer.ai/ticket/md): MonsterUI Help Desk Example - Professional Dashboard with DaisyUI components
+- [Forms](https://monsterui.answer.ai/forms/md): FrankenUI Forms Example built with MonsterUI (original design by ShadCN)
+- [Cards](https://monsterui.answer.ai/cards/md): FrankenUI Cards Example built with MonsterUI (original design by ShadCN)
+- [Music](https://monsterui.answer.ai/music/md): FrankenUI Music Example build with MonsterUI (Original design by ShadCN)
+
+## Optional
+- [Accordion | Link](https://monsterui.answer.ai/api_ref/docs_accordion_link/md): Internal Server Error
+- [Button | Link](https://monsterui.answer.ai/api_ref/docs_button_link/md): Internal Server Error
+- [Cards](https://monsterui.answer.ai/api_ref/docs_cards/md): Internal Server Error
+- [Charts](https://monsterui.answer.ai/api_ref/docs_charts/md): Internal Server Error
+- [Containers](https://monsterui.answer.ai/api_ref/docs_containers/md): Internal Server Error
+- [Dividers](https://monsterui.answer.ai/api_ref/docs_dividers/md): Internal Server Error
+- [Forms](https://monsterui.answer.ai/api_ref/docs_forms/md): Internal Server Error
+- [Html](https://monsterui.answer.ai/api_ref/docs_html/md): Internal Server Error
+- [Icons | Images](https://monsterui.answer.ai/api_ref/docs_icons_images/md): Internal Server Error
+- [Layout](https://monsterui.answer.ai/api_ref/docs_layout/md): Internal Server Error
+- [Lightbox](https://monsterui.answer.ai/api_ref/docs_lightbox/md): Internal Server Error
+- [Lists](https://monsterui.answer.ai/api_ref/docs_lists/md): Internal Server Error
+- [Loading](https://monsterui.answer.ai/api_ref/docs_loading/md): Internal Server Error
+- [Markdown](https://monsterui.answer.ai/api_ref/docs_markdown/md): Internal Server Error
+- [Modals](https://monsterui.answer.ai/api_ref/docs_modals/md): Internal Server Error
+- [Navigation](https://monsterui.answer.ai/api_ref/docs_navigation/md): Internal Server Error
+- [Notifications](https://monsterui.answer.ai/api_ref/docs_notifications/md): Internal Server Error
+- [Sliders](https://monsterui.answer.ai/api_ref/docs_sliders/md): Internal Server Error
+- [Steps](https://monsterui.answer.ai/api_ref/docs_steps/md): Internal Server Error
+- [Tables](https://monsterui.answer.ai/api_ref/docs_tables/md): Internal Server Error
+- [Theme | Headers](https://monsterui.answer.ai/api_ref/docs_theme_headers/md): Internal Server Error
+- [Typography](https://monsterui.answer.ai/api_ref/docs_typography/md): Internal Server Error
+- [Layout](https://monsterui.answer.ai/tutorial_layout/md): MonsterUI Page Layout Guide
+- [Spacing](https://monsterui.answer.ai/tutorial_spacing/md): Padding & Margin & Spacing, Oh my! (MonsterUI Spacing Guide)

--- a/main.py
+++ b/main.py
@@ -384,7 +384,7 @@ def all_tools_improvements():
         if tool_imps:
             imp_table = Table(
                     Thead(Tr(Th("Title"), Th("Priority", style="text-align:center"))),
-                    Tbody(*[Tr(Td(imp['title']), Td(str(imp['prio']), style="text-align:center"), style="cursor:pointer;", hx_get=f"/improvement?slug={imp['slug']}", hx_target="#main-content", hx_swap="innerHTML") for imp in tool_imps])
+                    Tbody(*[Tr(Td(imp['title']), Td(str(imp['prio']), style="text-align:center"), style="cursor:pointer;", hx_get=f"/improvement?id={imp['id']}", hx_target="#main-content", hx_swap="innerHTML") for imp in tool_imps])
             )
         else:
             imp_table = P("No improvements")
@@ -405,9 +405,10 @@ def all_tools_improvements():
     )
 
 @rt
-def improvement(slug: str):
-    imp_row = db.t.improvements("slug=?", (slug,))[0]
+def improvement(id: int=None):
+    imp_row = db.t.improvements("id=?", (id,))[0]
     imp = Improvement(**imp_row)
+    slug = imp.slug
     
     prio_color = "#0066cc" if imp.prio == 1 else "#666666"
     


### PR DESCRIPTION
Summary
- Replace improvement list links to use `id` instead of `slug` for hx_get requests
- Update `improvement` route to accept `id` (preferred) and fetch the record by `id`
- Keep downstream links (Edit, Tool) working by reusing the resolved `slug`

Motivation
When two improvements share the same title, their slugs can collide, causing both rows to navigate to the same page. Using the unique database `id` ensures stable, collision-free navigation.

Implementation Details
- main.py
  - all_tools_improvements(): change `hx_get` from `/improvement?slug=...` to `/improvement?id={imp['id']}`
  - improvement(...): signature changed to `def improvement(id: int=None)`; fetch by `id`, then set `slug = imp.slug` to keep existing links intact

Testing
- Created two improvements with identical titles under the same tool
- Verified each row opens its unique page
- Verified Edit and Tool links continue to function

Notes
- This PR addresses and closes #7
