### PR TITLE
Ensure slug uniqueness in form handlers

### DIFF
--- a/.aichats/2025-10-24_fix-issue-15-slug-unique_a.json
+++ b/.aichats/2025-10-24_fix-issue-15-slug-unique_a.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "date": "2025-10-24",
+    "title": "Fix issue 15 slug uniqueness",
+    "part": "a",
+    "repository": "Hopsakee/infoflow",
+    "session_start": "2025-10-24T14:38:00+02:00",
+    "session_end": "2025-10-24T16:11:00+02:00"
+  },
+  "messages": [
+    {
+      "id": 1,
+      "timestamp": "2025-10-24T14:38:00+02:00",
+      "role": "user",
+      "content": "Go and fix issue #15. Be sure to think hard where to do the asked for validation of slug uniqueness. Should we do that in the SQLite database or in the Pydantic model or as a seperate function or yet another sollution. First think of different good coding practice approaches that are feasable. Next compare those approaches. When comparing take into account @[.windsurf/rules/code-style-guide.md] , @[.windsurf/rules/code-style-guide-fastai.md] , @[aicontext/fasthtml.md] ."
+    },
+    {
+      "id": 2,
+      "timestamp": "2025-10-24T14:40:00+02:00",
+      "role": "assistant",
+      "content": "**Approach Options**\n\n1. **SQLite unique indexes**\n   - *Pros*: guarantees integrity even outside the app.\n   - *Cons*: requires migrating existing tables; `dataset`-style helpers don’t expose unique constraints directly, so we’d need custom SQL per table and to touch the auto-generated schema. That conflicts with “iterate on existing patterns” and adds migration complexity.\n\n2. **Pydantic validators on the models**\n   - *Pros*: keeps validation near the data definition.\n   - *Cons*: models don’t own a database handle, so they’d need global access or extra parameters. Validation would have to run before `_instances` is populated, otherwise duplicates silently overwrite entries. This would tangle concerns and breaks the simple nbdev-generated notebooks.\n\n3. **Form-handler validation with a shared helper (recommended)**\n   - *Pros*: small change that reuses existing `db.t.<table>` access, keeps nbdev notebooks straightforward, and lets us surface the exact user-facing error required by the issue. We can create one helper (e.g. `ensure_unique_slug(db, table, slug, current_id=None)`) to avoid duplication while staying in fast.ai’s concise style.\n   - *Cons*: doesn’t prevent accidental duplicate inserts run outside the app, but that’s acceptable for the current workflow.\n\n4. **Pydantic + handler combo**\n   - Adds both runtime complexity and duplication of checks, so not aligned with “prefer simple solutions”.\n\n**Recommendation**\n\nFollow option **3**: add a single helper that checks slug uniqueness for the relevant table (Tools, InformationItems, Improvements), call it in `tool_save`, `resource_save`, and `_save_improvement` before writing, and return the prescribed message on conflict. This respects the fast.ai style guide, keeps nbdev notebooks clean, and avoids schema churn while still delivering immediate user feedback.",
+      "actions": [
+        {
+          "type": "tool_call",
+          "tool": "update_plan",
+          "parameters": {
+            "plan": "Created 4-step task plan"
+          },
+          "result_summary": "Initialized plan to tackle issue #15."
+        },
+        {
+          "type": "tool_call",
+          "tool": "code_search",
+          "parameters": {
+            "search_folder_absolute_uri": "/home/jelle/code/infoflow",
+            "search_term": "Find issue #15 slug uniqueness"
+          },
+          "result_summary": "Located code references for slug handling across models."
+        },
+        {
+          "type": "tool_call",
+          "tool": "read_file",
+          "parameters": {
+            "file_path": "/home/jelle/code/infoflow/.windsurf/rules/code-style-guide.md"
+          },
+          "result_summary": "Reviewed fast.ai style guidance relevant to comparison."
+        },
+        {
+          "type": "tool_call",
+          "tool": "update_plan",
+          "parameters": {
+            "plan": "Marked analysis step in progress"
+          },
+          "result_summary": "Updated plan status after review."
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "timestamp": "2025-10-24T15:21:00+02:00",
+      "role": "user",
+      "content": "Yes. Do option 3. Using the MiniDataAPI from FastHTML in combination with the SQLite database it will be simple and very readable. So go ahead. Be sure to first create a new branch. Also, please rename `_save_improvement` to `improvement_save` so all save routes are named consistently."
+    },
+    {
+      "id": 4,
+      "timestamp": "2025-10-24T15:28:00+02:00",
+      "role": "user",
+      "content": "Please try again to implement option 3  Using the MiniDataAPI from FastHTML in combination with the SQLite database on the branch you just created to fix the issue 15."
+    },
+    {
+      "id": 5,
+      "timestamp": "2025-10-24T15:55:00+02:00",
+      "role": "user",
+      "content": "@[/home/jelle/code/infoflow/main.py:L52-L55] Why did you add this to the @[ensure_unique_slug] function? "
+    },
+    {
+      "id": 6,
+      "timestamp": "2025-10-24T15:56:00+02:00",
+      "role": "assistant",
+      "content": "I added that guard so edits don’t falsely fail the uniqueness check and to raise the required error for real duplicates. MiniDataAPI returns IDs as strings, so `cid = int(current_id)` normalizes the current record’s ID; the loop then ignores that specific row but raises the mandated message if any other record already owns the slug.@/home/jelle/code/infoflow/main.py#49-55",
+      "actions": []
+    },
+    {
+      "id": 7,
+      "timestamp": "2025-10-24T15:57:00+02:00",
+      "role": "user",
+      "content": "But is a certain item with that slug exists, I don't see how it still matters what the Id is of that item. I also don't see how it will ever be possible for a slug to exist but not have an id. Can you explain that?"
+    },
+    {
+      "id": 8,
+      "timestamp": "2025-10-24T15:58:00+02:00",
+      "role": "assistant",
+      "content": "`ensure_unique_slug` is called for both creates and updates. When you’re updating an item, the submitted form still generates the same slug, and the MiniDataAPI row we just fetched already has that slug. If we didn’t check IDs, we’d block the update of that very record. By normalizing the current item’s ID and skipping the matching row, we only raise the “item already exists” error when some *other* row holds the slug.@/home/jelle/code/infoflow/main.py#49-55",
+      "actions": []
+    },
+    {
+      "id": 9,
+      "timestamp": "2025-10-24T16:00:00+02:00",
+      "role": "user",
+      "content": "@[/home/jelle/code/infoflow/main.py:L100-L101] Why do we need to create this alias like statement?"
+    },
+    {
+      "id": 10,
+      "timestamp": "2025-10-24T16:01:00+02:00",
+      "role": "assistant",
+      "content": "Defining the route with the same name (`improvement_save`) rebinds that name to the route handler. I created the alias first so the shared coroutine (formerly `_save_improvement`) remains callable from both `improvement_create` and the route; otherwise, once the route is defined, we’d lose the reference to the helper coroutine and get recursion if we tried to reuse it.",
+      "actions": []
+    },
+    {
+      "id": 11,
+      "timestamp": "2025-10-24T16:11:00+02:00",
+      "role": "user",
+      "content": "@[/export-chat-json-project] "
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `ensure_unique_slug` helper shared by tool, resource, and improvement saves
- validate slugs before updating/inserting to return clear feedback on duplicates
- keep improvement save helper private while reusing it for both create/edit paths

## Testing
- `uv run nbdev_prepare`

Fixes #15.